### PR TITLE
Nav fixes

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,7 @@
     <!-- Workaround for z-index of drawer overlay -->
     <v-overlay :value="mobileDrawer"></v-overlay>
     <!-- Mobile Navigation Drawer -->
-    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher>
+    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-4">
       <v-list nav dense>
         <v-list-item-group>
           <v-list-item two-line to="/" active-class="deep-purple--text text--accent-4">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app v-resize="checkIsMobile">
+  <v-app v-resize="checkIsMobile" :class="{'no-scroll': mobileDrawer}">
     <v-app-bar app fixed color="#303030" dark hide-on-scroll scroll-threshold="100" dense prominent>
       <div class="d-flex justify-space-between align-center flex-no-wrap appBarContent">
         <!-- Mobile Hamburger Menu Button -->
@@ -114,6 +114,15 @@
 .appBarContent {
   width: 100%;
   height: 100%;
+}
+.no-scroll {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  overflow: hidden;
 }
 </style>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app v-resize="checkIsMobile">
-    <v-app-bar app fixed color="#303030" dark hide-on-scroll scroll-off-screen scroll-threshold="100" dense prominent>
+    <v-app-bar app fixed color="#303030" dark hide-on-scroll scroll-threshold="100" dense prominent>
       <div class="d-flex justify-space-between align-center flex-no-wrap appBarContent">
         <!-- Mobile Hamburger Menu Button -->
         <v-app-bar-nav-icon class="hidden-md-and-up" @click.stop="mobileDrawer = !mobileDrawer"></v-app-bar-nav-icon>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,7 @@
     <!-- Workaround for z-index of drawer overlay -->
     <v-overlay :value="mobileDrawer"></v-overlay>
     <!-- Mobile Navigation Drawer -->
-    <v-navigation-drawer v-model="mobileDrawer" app hide-overlay disable-resize-watcher>
+    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher>
       <v-list nav dense>
         <v-list-item-group>
           <v-list-item two-line to="/" active-class="deep-purple--text text--accent-4">
@@ -99,11 +99,11 @@
       </v-list>
     </v-navigation-drawer>
     <!-- Application Content -->
-    <v-content :class="{ noScroll: mobileDrawer }">
+    <v-main>
       <v-container fluid>
         <nuxt />
       </v-container>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 <style lang="css" scoped>
@@ -114,11 +114,6 @@
 .appBarContent {
   width: 100%;
   height: 100%;
-}
-.noScroll {
-  position: fixed;
-  top: 0px;
-  left: 0px;
 }
 </style>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,7 @@
     <!-- Workaround for z-index of drawer overlay -->
     <v-overlay :value="mobileDrawer"></v-overlay>
     <!-- Mobile Navigation Drawer -->
-    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-12">
+    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-16">
       <v-list nav dense>
         <v-list-item-group>
           <v-list-item two-line to="/" active-class="deep-purple--text text--accent-4">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -42,7 +42,7 @@
                   text
                   rounded
                   active-class="deep-purple--text text--accent-4"
-                  exact 
+                  exact
                 >
                   <v-list-item-title>
                     {{
@@ -63,7 +63,7 @@
     <!-- Workaround for z-index of drawer overlay -->
     <v-overlay :value="mobileDrawer"></v-overlay>
     <!-- Mobile Navigation Drawer -->
-    <v-navigation-drawer v-model="mobileDrawer" app disable-resize-watcher>
+    <v-navigation-drawer v-model="mobileDrawer" app hide-overlay disable-resize-watcher>
       <v-list nav dense>
         <v-list-item-group>
           <v-list-item two-line to="/" active-class="deep-purple--text text--accent-4">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app v-resize="checkIsMobile" v-bind:class="{ noScroll: mobileDrawer}">
+  <v-app v-resize="checkIsMobile">
     <v-app-bar app fixed color="#303030" dark hide-on-scroll scroll-off-screen scroll-threshold="100" dense prominent>
       <div class="d-flex justify-space-between align-center flex-no-wrap appBarContent">
         <!-- Mobile Hamburger Menu Button -->
@@ -99,7 +99,7 @@
       </v-list>
     </v-navigation-drawer>
     <!-- Application Content -->
-    <v-content>
+    <v-content :class="{ noScroll: mobileDrawer }">
       <v-container fluid>
         <nuxt />
       </v-container>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,7 @@
     <!-- Workaround for z-index of drawer overlay -->
     <v-overlay :value="mobileDrawer"></v-overlay>
     <!-- Mobile Navigation Drawer -->
-    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-4">
+    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-8">
       <v-list nav dense>
         <v-list-item-group>
           <v-list-item two-line to="/" active-class="deep-purple--text text--accent-4">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,7 @@
     <!-- Workaround for z-index of drawer overlay -->
     <v-overlay :value="mobileDrawer"></v-overlay>
     <!-- Mobile Navigation Drawer -->
-    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-8">
+    <v-navigation-drawer v-model="mobileDrawer" app fixed hide-overlay disable-resize-watcher class="pb-12">
       <v-list nav dense>
         <v-list-item-group>
           <v-list-item two-line to="/" active-class="deep-purple--text text--accent-4">

--- a/package-lock.json
+++ b/package-lock.json
@@ -15358,9 +15358,9 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "vuetify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.0.0.tgz",
-      "integrity": "sha512-AbtHkWdvxF3QrR/xCpu2XL+KJ59Z7/KQQmbV4gPn6Q3VlQ5tXaGR4AJO1uNrvGCTlLlQxWHGcwMGOiHU7aIlqg=="
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.3.5.tgz",
+      "integrity": "sha512-S1DN+Ct3z/Os77CUORmiN2Q802KmjcJnW5ZtKVTevB+ojGEM9BdAiUuUp7nOWeuv/Zc/LnhCP9M3DWHVscPsPA=="
     },
     "vuex": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "nuxt-ts": "^2.8.1",
     "prismic-javascript": "^2.7.1",
     "prismic-vue": "^2.0.1",
-    "vuetify": "^2.0.0"
+    "vuetify": "^2.3.5"
   },
   "devDependencies": {
     "@mdi/font": "^5.1.45",


### PR DESCRIPTION
Removed default nav drawer overlay: removes extra dimming
Moved noScroll class to main element: should resolve where the page content shifts right on drawer open. This should also improve scrolling when using the collapsible menu inside the mobile drawer.