### PR TITLE
Added ability to order products under each category.

### DIFF
--- a/store/products.ts
+++ b/store/products.ts
@@ -49,7 +49,9 @@ export const actions = {
       'my.products.product_category',
       catId
     )
-    const product = await $prismic.api.query(byCategory, {})
+    const product = await $prismic.api.query(byCategory, {
+      orderings: '[my.products.order_number]'
+    })
     commit(
       'addProducts',
       product.results.map((result) => result)


### PR DESCRIPTION
This branch gives you the ability to apply an ordering to products under their given category. The field for ordering products is in Prismic. NOTE: Ordering is optional and if the order is not given, products will be loaded in default order.